### PR TITLE
Display: Document title in debug mode

### DIFF
--- a/lib/inject.js
+++ b/lib/inject.js
@@ -22,7 +22,7 @@ function injectPa11y(window, options, done) {
 	function onCodeSnifferComplete() {
 		done({
 			messages: processMessages(window.HTMLCS.getMessages()),
-			documentTitle: window.document.title
+			documentTitle: window.document.title || ''
 		});
 	}
 

--- a/lib/inject.js
+++ b/lib/inject.js
@@ -21,7 +21,8 @@ function injectPa11y(window, options, done) {
 
 	function onCodeSnifferComplete() {
 		done({
-			messages: processMessages(window.HTMLCS.getMessages())
+			messages: processMessages(window.HTMLCS.getMessages()),
+			documentTitle: window.document.title
 		});
 	}
 

--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -63,6 +63,7 @@ function testPage(browser, page, options, done) {
 		if (result.error) {
 			return done(new Error(result.error));
 		}
+		options.log.debug(`Document title: "${result.documentTitle}"`);
 		done(null, result.messages);
 	});
 

--- a/test/unit/lib/inject.js
+++ b/test/unit/lib/inject.js
@@ -30,6 +30,15 @@ describe('lib/inject', function() {
 		});
 	});
 
+	it('should return result with messages and documentTitle properties', function(done) {
+		window.HTMLCS.getMessages.returns([]);
+		inject(window, options, function(result) {
+			assert.isDefined(result.messages);
+			assert.isDefined(result.documentTitle);
+			done();
+		});
+	});
+
 	it('should ignore messages when they are a child of `options.hideElements`', function(done) {
 		options.hideElements = '.hide';
 		window.document.querySelectorAll.returns([


### PR DESCRIPTION
cc @rowanmanning @lc512k

With `--debug` flag turned on, running `pa11y` will add to the debug logs the document title of the page tested.

This will allow user to ensure that passing tests are not false positives called from error pages which may not cause any pa11y errors/warnings while the actual page might. Naturally, this relies on the website being tested having appropriate document titles when a page errors (but given the variety of forms these may take it still requires human judgement to deduce whether test has been conducted on the intended page).

### Page found
![page-found](https://cloud.githubusercontent.com/assets/10484515/20628879/8eb699a6-b320-11e6-8c36-50b3840bc0e8.png)

### Page not found
![page-not-found](https://cloud.githubusercontent.com/assets/10484515/20628881/937b5c38-b320-11e6-9ea4-a61263412780.png)